### PR TITLE
Server

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+import websockets
+
+from merkato.merkato_config import get_config
+from merkato.parser import parse
+from merkato.utils.database_utils import no_merkatos_table_exists, create_merkatos_table, drop_merkatos_table, \
+    no_exchanges_table_exists, create_exchanges_table, drop_exchanges_table
+
+import logging
+log = logging.getLogger("client")
+
+"""
+Merkato WebSocket CLI client.
+This demonstrates the behavior that will eventually be moved to a Javascript GUI client.
+Establish a connection to server, get user input, send config to server,
+and loop awaiting updates from server. (In the GUI, it'll also loop awaiting user action e.g. button clicks.)
+"""
+
+
+async def client(url):
+    async with websockets.connect(url) as ws:
+        log.info("Connected.")
+
+        merkato_params = get_merkato_params_from_user()
+        log.info("Sending Merkato params {}".format(merkato_params))
+        await ws.send(json.dumps({'merkato_params': merkato_params}))
+
+        while True:
+            msg = await ws.recv()
+            print("Received {}".format(msg))
+
+
+def get_merkato_params_from_user():
+    print("Merkato Alpha v0.1.1\n")
+
+    if no_merkatos_table_exists():
+        create_merkatos_table()
+    else:
+        should_drop_merkatos = input('Do you want to drop merkatos? y/n: ')
+        if should_drop_merkatos == 'y':
+            drop_merkatos_table()
+            create_merkatos_table()
+
+    if no_exchanges_table_exists():
+        create_exchanges_table()
+    else:
+        should_drop_exchanges = input('Do you want to drop exchanges? y/n: ')
+        if should_drop_exchanges == 'y':
+            drop_exchanges_table()
+            create_exchanges_table()
+
+    configuration = parse()
+
+    if not configuration:
+        configuration = get_config()
+
+    if not configuration:
+        raise Exception("Failed to get configuration.")
+
+    base = input("Base: ")
+    coin = input("Coin: ")
+    spread = input("Spread: ")
+    coin_reserve = input("Coin reserve: ")
+    base_reserve = input("Base reserve: ")
+
+    return {
+        'configuration': configuration,
+        'base': base,
+        'coin': coin,
+        'spread': spread,
+        'bid_reserved_balance': base_reserve,
+        'ask_reserved_balance': coin_reserve
+    }
+
+
+if __name__ == "__main__":
+    url = "ws://localhost:5678"
+    asyncio.get_event_loop().run_until_complete(client(url))

--- a/client.py
+++ b/client.py
@@ -22,13 +22,17 @@ async def client(url):
     async with websockets.connect(url) as ws:
         log.info("Connected.")
 
-        merkato_params = get_merkato_params_from_user()
-        log.info("Sending Merkato params {}".format(merkato_params))
-        await ws.send(json.dumps({'merkato_params': merkato_params}))
+        try:
+            merkato_params = get_merkato_params_from_user()
+            log.info("Sending Merkato params {}".format(merkato_params))
+            await ws.send(json.dumps({'merkato_params': merkato_params}))
 
-        while True:
-            msg = await ws.recv()
-            print("Received {}".format(msg))
+            while True:
+                msg = await ws.recv()
+                print("Received {}".format(msg))
+        except websockets.ConnectionClosed:
+            log.error("Server unexpectedly closed connection, investigate.")
+            exit(1)
 
 
 def get_merkato_params_from_user():
@@ -68,9 +72,9 @@ def get_merkato_params_from_user():
         'configuration': configuration,
         'base': base,
         'coin': coin,
-        'spread': spread,
-        'bid_reserved_balance': base_reserve,
-        'ask_reserved_balance': coin_reserve
+        'spread': float(spread),
+        'bid_reserved_balance': float(base_reserve),
+        'ask_reserved_balance': float(coin_reserve)
     }
 
 

--- a/merkato/utils/database_utils.py
+++ b/merkato/utils/database_utils.py
@@ -76,8 +76,8 @@ def insert_merkato(exchange, exchange_pair='tuxBTC_ETH', base='BTC', alt='XMR', 
     finally:
         c = conn.cursor()
         c.execute("""REPLACE INTO merkatos 
-                    (exchange, exchange_pair, base, alt, spread, profit_limit, last_order, first_order, starting_price, ask_reserved_balance, bid_reserved_balance, profit_margin, base_partials_balance, quote_partials_balance, starting_price, quote_volume, base_volume) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""", 
-                    (exchange, exchange_pair, base, alt, spread, profit_limit, last_order, first_order, starting_price, ask_reserved_balance, bid_reserved_balance, profit_margin, 0, 0, 0, 0))
+                    (exchange, exchange_pair, base, alt, spread, profit_limit, last_order, first_order, starting_price, ask_reserved_balance, bid_reserved_balance, profit_margin, base_partials_balance, quote_partials_balance, starting_price, quote_volume, base_volume) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    (exchange, exchange_pair, base, alt, spread, profit_limit, last_order, first_order, starting_price, ask_reserved_balance, bid_reserved_balance, profit_margin, 0, 0, 0, 0, 0))
         conn.commit()
         conn.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tornado
 matplotlib
 cryptography
 python-binance
+websockets

--- a/server.py
+++ b/server.py
@@ -1,0 +1,42 @@
+import asyncio
+import json
+import websockets
+
+from merkato.merkato import Merkato
+
+# TODO: Run initial config when the client connects
+# TODO: write simple ws client
+
+class Server(object):
+    def __init__(self, *m_args, **m_kwargs):
+        self.merkato = Merkato(*m_args, **m_kwargs)
+
+    async def _consume(self, ws, path):
+        # Listen for incoming commands from client and translate them to method calls on Merkato.
+        async for message in ws:
+            data = json.loads(message)
+
+    async def _produce(self, ws, path):
+        # Run merkato.update() in a loop and send results to client for rendering.
+        while True:
+            data = self.merkato.update()
+            msg = json.dumps(data)
+            await ws.send(msg)
+
+    async def handler(self, ws, path):
+        # Runs the consumer and producer concurrently.
+        # TODO: I think here is where we put on-connected logic.
+        producer = asyncio.ensure_future(self._produce(ws, path))
+        consumer = asyncio.ensure_future(self._consume(ws, path))
+        done, pending = await asyncio.wait([producer, consumer])
+        for task in pending:
+            task.cancel()
+
+    def serve(self, port=5678):
+        return websockets.serve(self.handler, 'localhost', port)
+
+
+if __name__ == "__main__":
+    server = Server()
+    asyncio.get_event_loop().run_until_complete(server.serve())
+    asyncio.get_event_loop().run_forever()

--- a/server.py
+++ b/server.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import asyncio
 import json
 import websockets
@@ -9,11 +7,6 @@ from merkato.merkato import Merkato
 import logging
 log = logging.getLogger("server")
 
-wslog = logging.getLogger('websockets')
-wslog.setLevel(logging.INFO)
-wslog.addHandler(logging.StreamHandler())
-
-# TODO: Robust error-handling throughout
 # TODO: Translate incoming messages to Merkato method calls
 # TODO: Security: restrict origins to localhost?
 

--- a/server.py
+++ b/server.py
@@ -21,6 +21,12 @@ class Server(object):
         async for message in ws:
             data = json.loads(message)
             log.info("Received data: {}".format(data))
+            if 'call' in data:
+                name = data['call']
+                args = data['args']
+                rval = self.merkato.__dict__[name](*args)
+                rmsg = {'return': name, 'value': rval}
+                await ws.send(json.dumps(rmsg))
 
     async def _produce(self, ws, path):
         # Run merkato.update() in a loop and send results to client for rendering.


### PR DESCRIPTION
This (WIP) introduces a websocket-based Python server, for use with an eventual web/electron GUI.

Why websockets?

- As opposed to just HTTP endpoints, they allow for bidirectional communication and pushing updates from server to client.
- As opposed to raw TCP sockets: they're easier and more pleasant to work with, in both python and JS. A websocket buffer provides a stream of messages, not just a stream of bytes.

To test:
- Run `server.py` in the background or another tab
- Run `client.py`, go through the config song & dance, and then the connection will start

The `async`/`await` features used here work best in Python >= 3.6. If needed it can be made compatible down to 3.4 but will be less nice looking.