### PR TITLE
Refactor buy and sell sides

### DIFF
--- a/merkato/exchanges/exchange_base.py
+++ b/merkato/exchanges/exchange_base.py
@@ -2,33 +2,29 @@ from abc import ABC, abstractmethod
 
 
 class ExchangeBase(ABC):
-	"""
-	Abstract base class for exchange interfaces. 
-	A new exchange can be implemented by overriding all abstract methods and members below;
-	it may define additional methods for exchange-specific behavior.
-	"""
-	url = NotImplemented
+    """
+    Abstract base class for exchange interfaces.
+    A new exchange can be implemented by overriding all abstract methods and members below;
+    it may define additional methods for exchange-specific behavior.
+    """
+    url = NotImplemented
 
-	@abstractmethod
-	def buy(self, amount, ask):
-		pass
+    @abstractmethod
+    def order(self, amount, ask):
+        pass
 
-	@abstractmethod
-	def sell(self, amount, bid):
-		pass
+    @abstractmethod
+    def get_all_orders(self):
+        pass
 
-	@abstractmethod
-	def get_all_orders(self):
-		pass
+    @abstractmethod
+    def get_my_open_orders(self):
+        pass
 
-	@abstractmethod
-	def get_my_open_orders(self):
-		pass
+    @abstractmethod
+    def get_my_trade_history(self):
+        pass
 
-	@abstractmethod
-	def get_my_trade_history(self):
-		pass
-
-	@abstractmethod
-	def cancel_order(self, order_id):
-		pass
+    @abstractmethod
+    def cancel_order(self, order_id):
+        pass

--- a/merkato/exchanges/tux_exchange/exchange.py
+++ b/merkato/exchanges/tux_exchange/exchange.py
@@ -31,127 +31,59 @@ class TuxExchange(ExchangeBase):
         self.name = 'tux'
 
 
-    def _sell(self, amount, ask):
-        ''' Places a sell for a number of an asset at the indicated price (0.00000503 for example)
-            :param amount: string
-            :param ask: float
-            :param ticker: string
-        '''
-        query_parameters = getQueryParameters(SELL, self.coin, amount, ask)
-        log.info(query_parameters)
-        response = self._create_signed_request(query_parameters)
+    def is_market_order(self, side, price):
+        assert side in (BUY, SELL), "Invalid side {}".format(side)
+        if side == BUY:
+            if Decimal(self.get_lowest_ask()) < price:
+                return True
+        elif side == SELL:
+            if Decimal(self.get_highest_bid()) > price:
+                return True
+        return False
+
+
+    def order(self, side, amount, price):
+        attempt = 0
+        while attempt < self.retries:
+            if self.limit_only and self.is_market_order(side, price):
+                    log.info(
+                        "{} {} {} at {} on {} FAILED - would make a market order.".format(side, amount, self.ticker, price,
+                                                                                            "tux"))
+                    return MARKET  # Maybe needs failed or something
+
+            try:
+                success = self._order(side, amount, price)
+
+                if success:
+                    log.info("{} {} {} at {} on {}".format(side, amount, self.ticker, price, "tux"))
+                    return success
+
+                else:
+                    log.info("{} {} {} at {} on {} FAILED - attempt {} of {}".format(side, amount, self.ticker, price, "tux",
+                                                                                       attempt, self.retries))
+                    attempt += 1
+                    time.sleep(1)
+
+            except Exception as e:  # TODO - too broad exception handling
+                raise ValueError(e)
+
+
+    def _order(self, side, amount, price):
+        query_params = getQueryParameters(side, self.coin, amount, price)
+        log.info(query_params)
+        response = self._create_signed_request(query_params)
         log.info(response)
         return response['success']
 
 
-    def sell(self, amount, ask):
+    def market_order(self, side, amount, price):
         ''' Amount is denominated in the quote asset
         '''
-        attempt = 0
-        while attempt < self.retries:
-            if self.limit_only:
-                # Get current highest bid on the orderbook
-                # If ask price is lower than the highest bid, return.
-
-                if Decimal(self.get_highest_bid()) > ask:
-                    log.info("SELL {} {} at {} on {} FAILED - would make a market order.".format(amount,self.ticker, ask, "tux"))
-                    return MARKET # Maybe needs failed or something
-
-            try:
-                success = self._sell(amount, ask)
-
-                if success:
-                    log.info("SELL {} {} at {} on {}".format(amount, self.ticker, ask, "tux"))
-                    return success
-
-                else:
-                    log.info("SELL {} {} at {} on {} FAILED - attempt {} of {}".format(amount, self.ticker, ask, "tux", attempt, self.retries))
-                    attempt += 1
-                    time.sleep(1)
-
-            except Exception as e:  # TODO - too broad exception handling
-                raise ValueError(e)
-
-    def market_buy(self, amount, bid):
-        ''' Amount is denominated in the quote asset
-        '''
-        attempt = 0
-        bid_amount = amount 
-        while attempt < self.retries:
-            try:
-                success = self._buy(bid_amount, bid)
-                if success:
-                    log.info("BUY {} {} at {} on {}".format(bid_amount, self.ticker, bid, "tux"))
-                    return success
-
-                else:
-                    log.info("BUY {} {} at {} on {} FAILED - attempt {} of {}".format(amount, self.ticker, bid, "tux", attempt, self.retries))
-                    attempt += 1
-                    time.sleep(1)
-
-            except Exception as e:  # TODO - too broad exception handling
-                raise ValueError(e)
-
-    def market_sell(self, amount, ask):
-        ''' Amount is denominated in the quote asset
-        '''
-        attempt = 0
-        try:
-            success = self._sell(amount, ask)
-
-            if success:
-                log.info("SELL {} {} at {} on {}".format(amount, self.ticker, ask, "tux"))
-                return success
-
-            else:
-                log.info("SELL {} {} at {} on {} FAILED - attempt {} of {}".format(amount, self.ticker, ask, "tux", attempt, self.retries))
-                attempt += 1
-                time.sleep(1)
-
-        except Exception as e:  # TODO - too broad exception handling
-            raise ValueError(e)
-
-    def _buy(self, amount, bid):
-        ''' Places a buy for a number of an asset at the indicated price (0.00000503 for example)
-            :param amount: string
-            :param bid: float
-            :param ticker: string
-        '''
-        query_parameters = getQueryParameters(BUY, self.coin, amount, bid)
-        log.info(query_parameters)
-        response = self._create_signed_request(query_parameters)
-        log.info(response)
-        return response['success']
-
-
-    def buy(self, amount, bid):
-        ''' Amount is denominated in the quote asset
-        '''
-        attempt = 0
-        bid_amount = amount
-        while attempt < self.retries:
-            if self.limit_only:
-                # Get current lowest ask on the orderbook
-                # If bid price is higher than the lowest ask, return.
-
-                if Decimal(self.get_lowest_ask()) < bid:
-
-                    log.info("BUY {} {} at {} on {} FAILED - would make a market order.".format(amount, self.ticker, bid, "tux"))
-                    return MARKET # Maybe needs failed or something
-
-            try:
-                success = self._buy(bid_amount, bid)
-                if success:
-                    log.info("BUY {} {} at {} on {}".format(bid_amount, self.ticker, bid, "tux"))
-                    return success
-
-                else:
-                    log.info("BUY {} {} at {} on {} FAILED - attempt {} of {}".format(amount, self.ticker, bid, "tux", attempt, self.retries))
-                    attempt += 1
-                    time.sleep(1)
-
-            except Exception as e:  # TODO - too broad exception handling
-                raise ValueError(e)
+        _limit_only = self.limit_only
+        self.limit_only = False
+        rval = self.order(side, amount, price)
+        self.limit_only = _limit_only
+        return rval
 
 
     def get_all_orders(self):
@@ -251,7 +183,7 @@ class TuxExchange(ExchangeBase):
         log.info(response)
         pair_balances = {"base" : {"amount": response[self.base],
                                    "name" : self.base},
-                         "coin": {"amount": response[self.coin],
+                         "quote": {"amount": response[self.coin],
                                   "name": self.coin},
                         }
 

--- a/merkato/merkato.py
+++ b/merkato/merkato.py
@@ -146,6 +146,7 @@ class Merkato(object):
 
             self.apply_filled_difference(tx, total_amount)
             self.volumes[side] += total_amount * Decimal(float(price))      # todo is this supposed to differ for buy and sell??
+            key = 'base'
             update_merkato(self.mutex_UUID, BASE_VOLUME, float(self.volumes[side]))
 
             if market != MARKET: 

--- a/merkato/merkato.py
+++ b/merkato/merkato.py
@@ -17,6 +17,7 @@ from merkato.utils import create_price_data, validate_merkato_initialization, ge
 log = logging.getLogger(__name__)
 getcontext().prec = 8
 
+
 @log_all_methods
 class Merkato(object):
     def __init__(self, configuration, coin, base, spread,
@@ -165,7 +166,10 @@ class Merkato(object):
             self.handle_market_order(*order)
 
         self.log_new_cointrackr_transactions(ordered_transactions)
-        log.info('ending partials base: {} quote: {}'.format(self.base_partials_balance, self.quote_partials_balance))
+        log.info('ending partials base: {} quote: {}'.format(
+            self.partials_balances['base'],
+            self.partials_balances['quote'])
+        )
         return ordered_transactions
 
 

--- a/merkato/merkato.py
+++ b/merkato/merkato.py
@@ -31,19 +31,19 @@ class Merkato(object):
         self.spread = Decimal(spread)
         self.profit_margin = Decimal(profit_margin)
         self.starting_price = starting_price
-        self.quote_volume = Decimal(quote_volume)
-        self.base_volume = Decimal(base_volume)
         self.step = 1.0033
+        self.volumes = {'base': Decimal(base_volume), 'quote': Decimal(quote_volume)}
         # Exchanges have a maximum number of orders every user can place. Due
         # to this, every Merkato has a reserve of coins that are not currently
         # allocated. As the price approaches unallocated regions, the reserves
         # are deployed.
-        self.bid_reserved_balance = Decimal(float(bid_reserved_balance))
-        self.ask_reserved_balance = Decimal(float(ask_reserved_balance))
+        self.reserved_balances = {
+            'ask': Decimal(float(ask_reserved_balance)),
+            'bid': Decimal(float(bid_reserved_balance))
+        }
 
         # The current sum of all partially filled orders
-        self.base_partials_balance = 0
-        self.quote_partials_balance = 0
+        self.partials_balances = {'base': 0, 'quote': 0}
 
         self.user_interface = user_interface
 
@@ -73,7 +73,7 @@ class Merkato(object):
                 log.debug('updating history first ID: {}'.format(history[0][ID]))
                 new_last_order = history[0][ID]
                 update_merkato(self.mutex_UUID, LAST_ORDER, new_last_order)
-            self.distribute_initial_orders(total_base=bid_reserved_balance, total_alt=ask_reserved_balance)
+            self.distribute_initial_orders(total_base=bid_reserved_balance, total_quote=ask_reserved_balance)
 
         else:
             first_order = get_first_order(self.mutex_UUID)
@@ -111,6 +111,7 @@ class Merkato(object):
             orderid = tx['orderId']
             tx_id   = tx[ID]
             price   = tx[PRICE]
+            side    = tx[TYPE]
 
             filled_amount = Decimal(tx['amount'])
             init_amount   = Decimal(tx['initamount'])
@@ -133,35 +134,19 @@ class Merkato(object):
                 self.handle_is_in_filled_orders(tx)
                 continue
 
-            if tx[TYPE] == SELL:
-                buy_price = Decimal(price) * ( 1  - self.spread)
-                log.info("Found sell {} corresponding buy price: {} amount: {}".format(tx, buy_price, amount))
+            sign = 1 if side == BUY else -1
+            price = Decimal(price) * (1 + self.spread*sign)
+            log.info("Found sell {} corresponding buy price: {} amount: {}".format(tx, price, amount))
 
-                market = self.exchange.buy(amount, buy_price)
-                # A lock is probably needed somewhere near here in case of unexpected shutdowns
+            market = self.exchange.order(side, amount, price)
 
-                if market == MARKET:
-                    log.info('market buy {}'.format(market))
-                    market_orders.append((amount, buy_price, BUY,))
+            if market == MARKET:
+                log.info('market {} {}'.format(side, market))
+                market_orders.append((amount, price, side,))
 
-                self.apply_filled_difference(tx, total_amount)
-                self.base_volume += total_amount * Decimal(float(price))
-                update_merkato(self.mutex_UUID, BASE_VOLUME, float(self.base_volume))
-
-            if tx[TYPE] == BUY:
-                sell_price = Decimal(price) * ( 1  + self.spread)
-
-                log.info("Found buy {} corresponding sell price: {} amount: {}".format(tx, sell_price, amount))
-
-                market = self.exchange.sell(amount, sell_price)
-                
-                if market == MARKET:
-                    log.info('market sell {}'.format(market))
-                    market_orders.append((amount, sell_price, SELL,))
-
-                self.apply_filled_difference(tx, total_amount)
-                self.quote_volume += total_amount
-                update_merkato(self.mutex_UUID, QUOTE_VOLUME, float(self.quote_volume))
+            self.apply_filled_difference(tx, total_amount)
+            self.volumes[side] += total_amount * Decimal(float(price))      # todo is this supposed to differ for buy and sell??
+            update_merkato(self.mutex_UUID, BASE_VOLUME, float(self.volumes[side]))
 
             if market != MARKET: 
                 log.info('market != MARKET')
@@ -198,10 +183,56 @@ class Merkato(object):
                 log.info('apply_filled_difference quote_partials_balance: {}'.format(self.quote_partials_balance))
 
 
-    def decaying_bid_ladder(self, total_amount, step, start_price):
-        '''total_amount is denominated in the base asset (BTC)
-        '''
-        # Abandon all hope, ye who enter here. This function uses black magic (math).
+    def distribute_initial_orders(self, total_base, total_quote):
+        """
+        Called once on initialization to distribute base and quote balances in orders.
+        :param total_base:
+        :param total_quote:
+        :return:
+        """
+        current_price = (Decimal(self.exchange.get_highest_bid()) + Decimal(self.exchange.get_lowest_ask())) / 2
+        if self.user_interface:
+            current_price = Decimal(self.user_interface.confirm_price(current_price))
+            update_merkato(self.mutex_UUID, STARTING_PRICE, current_price)
+        ask_start = current_price + current_price * self.spread / 2
+        bid_start = current_price - current_price * self.spread / 2
+
+        self.distribute(BUY, bid_start, total_base, self.step)
+        self.distribute(SELL, ask_start, total_quote, self.step)
+
+
+    def distribute(self, side, price, total_to_distribute, step):
+        """
+        Allocates your market making balance on one side, in a way that will never be completely exhausted (run out).
+        :param side: merkato.constants.BUY or SELL
+        :param price: Starting price
+        :param total_to_distribute:
+        :param step:
+        :return:
+        """
+
+        # 2. Call decaying_bid_ladder on that start price, with the given step,
+        #    and half the total_to_distribute
+        self.decaying_ladder(side, Decimal(total_to_distribute/2), step, price)
+
+        # 3. Call decaying_bid_ladder again halving the
+        #    start_price, and halving the total_amount
+        self.decaying_ladder(side, Decimal(total_to_distribute/4), step, price/2)
+
+
+    def decaying_ladder(self, side, total_amount, step, start_price):
+        """
+        Places a ladder from the start_price to 2x the start_price.
+        The last order in the ladder is half the amount of the first
+        order in the ladder. The amount allocated at each step decays as
+        orders are placed.
+        Abandon all hope, ye who enter here. This function uses black magic (math).
+        :param side: merkato.constants.BUY or SELL
+        :param total_amount: Denominated in the base asset (e.g. BTC)
+        :param step:
+        :param start_price:
+        :return:
+        """
 
         scaling_factor = 0
         total_orders = floor(math.log(2, step)) # 277 for a step of 1.0025
@@ -215,20 +246,20 @@ class Merkato(object):
         current_order = 0
         amount = 0
 
-        prior_reserve = self.bid_reserved_balance
+        prior_reserve = self.reserved_balances[side]
         while current_order < total_orders:
             step_adjusted_factor = Decimal(step**current_order)
-            current_bid_price = Decimal(start_price/step_adjusted_factor)
-            current_bid_total = Decimal(Decimal(total_amount)/(scaling_factor * step_adjusted_factor))
-            current_bid_amount = Decimal(Decimal(total_amount)/(scaling_factor * step_adjusted_factor))/current_bid_price
-            amount += current_bid_amount
+            current_price = Decimal(start_price/step_adjusted_factor)
+            current_total = Decimal(Decimal(total_amount)/(scaling_factor * step_adjusted_factor))
+            current_amount = Decimal(Decimal(total_amount)/(scaling_factor * step_adjusted_factor))/current_price
+            amount += current_amount
             
             # TODO Create lock
-            response = self.exchange.buy(current_bid_amount, current_bid_price)
+            response = self.exchange.order(side, current_amount, current_price)
 
             log.info('bid response {}'.format(response))
 
-            self.remove_reserve(current_bid_total, BID_RESERVE) 
+            self.remove_reserve(current_total, BID_RESERVE)     # TODO make this side-agnostic
             # TODO Release lock
             
             current_order += 1
@@ -252,93 +283,12 @@ class Merkato(object):
         update_merkato(self.mutex_UUID, LAST_ORDER, tx_id)
 
 
-    def distribute_bids(self, price, total_to_distribute):
-        # Allocates your market making balance on the bid side, in a way that
-        # will never be completely exhausted (run out).
-        # total_to_distribute is in the base currency (usually BTC)
-
-        # 2. Call decaying_bid_ladder on that start price, with the given step,
-        #    and half the total_to_distribute
-        self.decaying_bid_ladder(Decimal(total_to_distribute/2), step, price)
-
-        # 3. Call decaying_bid_ladder again halving the
-        #    start_price, and halving the total_amount
-        self.decaying_bid_ladder(Decimal(total_to_distribute/4), step, price/2)
-
-
     def get_total_amount(self, init_amount, orderid):
         if self.exchange.name == "tux":
             return Decimal(init_amount)
 
         else:
             return self.exchange.get_total_amount(orderid) # todo unimplemented on tux
-
-
-    def decaying_ask_ladder(self, total_amount, step, start_price):
-        # Places an ask ladder from the start_price to 2x the start_price.
-        # The last order in the ladder is half the amount of the first
-        # order in the ladder. The amount allocated at each step decays as
-        # orders are placed.
-        # Abandon all hope, ye who enter here. This function uses black magic (math).
-
-        scaling_factor = 0
-        total_orders = floor(math.log(2, step)) # 277 for a step of 1.0025
-        current_order = 0
-
-        # Calculate scaling factor
-        while current_order < total_orders:
-            scaling_factor += Decimal(1/(step**current_order))
-            current_order += 1
-
-        current_order = 0
-        amount = 0
-
-        prior_reserve = self.ask_reserved_balance
-        while current_order < total_orders:
-            step_adjusted_factor = Decimal(step**current_order)
-            current_ask_amount = total_amount/(scaling_factor * step_adjusted_factor)
-            current_ask_price = start_price*step_adjusted_factor
-            amount += current_ask_amount
-
-            # TODO Create lock
-            response = self.exchange.sell(current_ask_amount, current_ask_price)
-
-            log.info('ask response {}'.format(response))
-
-            self.remove_reserve(current_ask_amount, ASK_RESERVE) 
-            # TODO Release lock
-
-            current_order += 1
-            self.avoid_blocking()
-
-        log.info('allocated amount: {}'.format(prior_reserve - self.ask_reserved_balance))
-
-
-    def distribute_asks(self, price, total_to_distribute):
-        # Allocates your market making balance on the ask side, in a way that
-        # will never be completely exhausted (run out).
-
-        # 2. Call decaying_ask_ladder on that start price, with the given step,
-        #    and half the total_to_distribute
-        self.decaying_ask_ladder(Decimal(total_to_distribute/2), self.step, price)
-
-        # 3. Call decaying_ask_ladder once more, doubling the
-        #    start_price, and halving the total_amount
-        self.decaying_ask_ladder(Decimal(total_to_distribute/4), self.step, price * 2)
-
-
-    def distribute_initial_orders(self, total_base, total_alt):
-        ''' TODO: Function comment
-        '''
-        current_price = (Decimal(self.exchange.get_highest_bid()) + Decimal(self.exchange.get_lowest_ask()))/2
-        if self.user_interface:
-            current_price = Decimal(self.user_interface.confirm_price(current_price))
-            update_merkato(self.mutex_UUID, STARTING_PRICE, current_price)
-        ask_start = current_price + current_price*self.spread/2
-        bid_start = current_price - current_price*self.spread/2
-        
-        self.distribute_bids(bid_start, total_base)
-        self.distribute_asks(ask_start, total_alt)
 
 
     def handle_partial_fill(self, type, filled_qty, tx_id):

--- a/tests/test_exchange_binance.py
+++ b/tests/test_exchange_binance.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import patch
 
+from merkato.constants import BUY, SELL
 from merkato.exchanges.binance_exchange.exchange import BinanceExchange
 from binance import enums
 
@@ -12,24 +13,26 @@ class BinanceExchangeTestCase(unittest.TestCase):
             self.exchange = BinanceExchange(config, 'XMR', 'BTC')
 
     def test_buy(self):
-        self.exchange._buy(1.0, 0.01)
+        self.exchange._order(BUY, 1.0, 0.01)
 
         self.exchange.client.create_order.assert_called_once_with(
             symbol='XMRBTC',
             side=enums.SIDE_BUY,
             type=enums.ORDER_TYPE_LIMIT,
             timeInForce=enums.TIME_IN_FORCE_GTC,
+            recvWindow=10000000,
             price='0.010000',
             quantity='1.000')
 
     def test_sell(self):
-        self.exchange._sell(1.0, 0.01)
+        self.exchange._order(SELL, 1.0, 0.01)
 
         self.exchange.client.create_order.assert_called_once_with(
             symbol='XMRBTC',
             side=enums.SIDE_SELL,
             type=enums.ORDER_TYPE_LIMIT,
             timeInForce=enums.TIME_IN_FORCE_GTC,
+            recvWindow=10000000,
             price='0.010000',
             quantity='1.000')
 

--- a/tests/test_exchange_tux.py
+++ b/tests/test_exchange_tux.py
@@ -2,46 +2,59 @@ import unittest
 from mock import patch
 from freezegun import freeze_time
 
+from merkato.constants import BUY, SELL
 from merkato.exchanges.tux_exchange.exchange import TuxExchange
 
 
 class TuxExchangeTestCase(unittest.TestCase):
-	def setUp(self):
-		config = {"private_api_key": "abc123", "public_api_key": "456def", "limit_only": False}
-		self.exchange = TuxExchange(config, 'XMR', 'BTC')
+    def setUp(self):
+        config = {"private_api_key": "abc123", "public_api_key": "456def", "limit_only": False}
+        self.exchange = TuxExchange(config, 'XMR', 'BTC')
 
-	@freeze_time('2001-01-01T12:00:00.0000')
-	@patch('merkato.exchanges.tux_exchange.exchange.requests.post')
-	def test_create_signed_request(self, post_mock):
-		query_params = {"foo": "bar"}
+    @freeze_time('2001-01-01T12:00:00.0000')
+    @patch('merkato.exchanges.tux_exchange.exchange.requests.post')
+    def test_create_signed_request(self, post_mock):
+        query_params = {"foo": "bar"}
 
-		self.exchange._create_signed_request(query_params)
+        self.exchange._create_signed_request(query_params)
 
-		post_mock.assert_called_once_with(
-			'https://tuxexchange.com/api', 
-			data={
-				'foo': 'bar', 
-				'nonce': 978350400000
-			}, 
-			headers={
-				'Key': '456def', 
-				'Sign': 'fbc8f9574ddab11d841f25f33d02854fe4932c91695611a9262f444220c4eb09ea9544af45a17d398fa623fa983ba47d38cdfe0a65483444f241ef5b9b34c621'
-			}, 
-			timeout=15
-		)
+        post_mock.assert_called_once_with(
+            'https://tuxexchange.com/api',
+            data={
+                'foo': 'bar',
+                'nonce': 978350400000
+            },
+            headers={
+                'Key': '456def',
+                'Sign': 'fbc8f9574ddab11d841f25f33d02854fe4932c91695611a9262f444220c4eb09ea9544af45a17d398fa623fa983ba47d38cdfe0a65483444f241ef5b9b34c621'
+            },
+            timeout=15
+        )
 
-	@patch('merkato.exchanges.tux_exchange.exchange.TuxExchange._create_signed_request')
-	def test_buy(self, signed_request_mock):
-		self.exchange.buy(1, 0.001)
+    @patch('merkato.exchanges.tux_exchange.exchange.TuxExchange._create_signed_request')
+    def test_buy(self, signed_request_mock):
+        self.exchange._order(BUY, 1, 0.001)
 
-		signed_request_mock.assert_called_once_with({
-			'method': 'buy', 
-			'market': 'BTC', 
-			'coin': 'XMR', 
-			'amount': '1000.00000000',
-			'price': '0.00100000'
-		})
+        signed_request_mock.assert_called_once_with({
+            'method': 'buy',
+            'market': 'BTC',
+            'coin': 'XMR',
+            'amount': '1.00000000',
+            'price': '0.00100000'
+        })
+
+    @patch('merkato.exchanges.tux_exchange.exchange.TuxExchange._create_signed_request')
+    def test_sell(self, signed_request_mock):
+        self.exchange._order(SELL, 1, 0.001)
+
+        signed_request_mock.assert_called_once_with({
+            'method': 'sell',
+            'market': 'BTC',
+            'coin': 'XMR',
+            'amount': '1.00000000',
+            'price': '0.00100000'
+        })
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/tests/test_merkato.py
+++ b/tests/test_merkato.py
@@ -1,6 +1,7 @@
 import unittest
 from mock import patch, MagicMock
 
+from merkato.constants import BUY, SELL
 from merkato.merkato import Merkato
 
 
@@ -22,12 +23,12 @@ class MerkatoTestCase(unittest.TestCase):
         self.merkato.exchange.sell.assert_not_called()
 
     def test_rebalance_orders(self):
-        pass
+        fake_new_txes = [
+            # todo make some fake transactions here
+            {'orderId': 0, 'id': 0, 'price': 0, 'type': BUY},
+        ]
 
-    def test_create_bid_ladder(self):
-        pass
-
-    def test_create_ask_ladder(self):
+    def test_decaying_ladder(self):
         pass
 
     def test_merge_orders(self):

--- a/tests/test_merkato.py
+++ b/tests/test_merkato.py
@@ -5,35 +5,36 @@ from merkato.merkato import Merkato
 
 
 class MerkatoTestCase(unittest.TestCase):
-	@patch('merkato.merkato.merkato_exists', return_value=True)
-	@patch('merkato.merkato.get_first_order', return_value=None)
-	@patch('merkato.merkato.get_last_order', return_value=None)
-	@patch('merkato.merkato.get_relevant_exchange', return_value=MagicMock())
-	def setUp(self, *_):
-		config = {"exchange": "tux", "private_api_key": "abc123", "public_api_key": "def456", "limit_only": False}
-		self.merkato = Merkato(config, coin='XMR', base='BTC', spread='.1',
-							   bid_reserved_balance='1', ask_reserved_balance='1')
+    @patch('merkato.merkato.merkato_exists', return_value=True)
+    @patch('merkato.merkato.get_first_order', return_value=None)
+    @patch('merkato.merkato.get_last_order', return_value=None)
+    @patch('merkato.merkato.get_relevant_exchange', return_value=MagicMock())
+    def setUp(self, *_):
+        config = {"exchange": "tux", "private_api_key": "abc123", "public_api_key": "def456", "limit_only": False}
+        self.merkato = Merkato(config, coin='XMR', base='BTC', spread='.1',
+                               bid_reserved_balance='1', ask_reserved_balance='1')
 
-	def test_rebalance_orders__no_new_txes(self):
-		result = self.merkato.rebalance_orders([])
-		self.assertEqual(result, [])
-		self.merkato.exchange.buy.assert_not_called()
-		self.merkato.exchange.sell.assert_not_called()
+    def test_rebalance_orders__no_new_txes(self):
+        result = self.merkato.rebalance_orders([])
 
-	def test_rebalance_orders(self):
-		pass
+        self.assertEqual(result, [])
+        self.merkato.exchange.buy.assert_not_called()
+        self.merkato.exchange.sell.assert_not_called()
 
-	def test_create_bid_ladder(self):
-		pass
+    def test_rebalance_orders(self):
+        pass
 
-	def test_create_ask_ladder(self):
-		pass
+    def test_create_bid_ladder(self):
+        pass
 
-	def test_merge_orders(self):
-		pass
+    def test_create_ask_ladder(self):
+        pass
 
-	def test_update_order_book(self):
-		pass
+    def test_merge_orders(self):
+        pass
 
-	def test_cancelrange(self):
-		pass
+    def test_update_order_book(self):
+        pass
+
+    def test_cancelrange(self):
+        pass


### PR DESCRIPTION
This would consolidate most functions which have nearly the same code differing only on whether they are "buy" or "sell" side, into single functions.

Motivation:
- Reduce code duplication
- Make testing easier / less tedious
- Most exchange APIs themselves only have one 'order' method (with side as a parameter) anyway

As this is a fairly high-touch refactor, I'll make sure to add unit tests, and confirm they pass before merging.
